### PR TITLE
Fix oauth handshake

### DIFF
--- a/ajax/oauth2.php
+++ b/ajax/oauth2.php
@@ -55,6 +55,12 @@ if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST
 		} else if ($step == 2 && isset($_POST['code'])) {
 			try {
 				$token = $client->authenticate((string)$_POST['code']);
+				if (isset($token['error'])) {
+					OCP\JSON::error(['data' => [
+						'message' => $l->t('Step 2 failed. Exception: %s', [$token['error_description']])
+					]]);
+					return;
+				}
 				OCP\JSON::success(['data' => [
 					'token' => $token
 				]]);

--- a/ajax/oauth2.php
+++ b/ajax/oauth2.php
@@ -25,14 +25,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-set_include_path(get_include_path().PATH_SEPARATOR.
-	\OC_App::getAppPath('files_external').'/3rdparty/google-api-php-client/src');
-require_once 'Google/autoload.php';
 
-OCP\JSON::checkAppEnabled('files_external');
 OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
-$l = \OC::$server->getL10N('files_external');
+$l = \OC::$server->getL10N('files_external_gdrive');
 
 // FIXME: currently hard-coded to Google Drive
 if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST['redirect'])) {

--- a/ajax/oauth2.php
+++ b/ajax/oauth2.php
@@ -62,7 +62,7 @@ if (isset($_POST['client_id']) && isset($_POST['client_secret']) && isset($_POST
 					return;
 				}
 				OCP\JSON::success(['data' => [
-					'token' => $token
+					'token' => json_encode($token)
 				]]);
 			} catch (Exception $exception) {
 				OCP\JSON::error(['data' => [

--- a/lib/Backend/Google.php
+++ b/lib/Backend/Google.php
@@ -42,7 +42,7 @@ class Google extends Backend {
 				// all parameters handled in OAuth2 mechanism
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)
-			->addCustomJs('gdrive')
+			->addCustomJs(['files_external_gdrive', 'gdrive'])
 		;
 	}
 

--- a/lib/Storage/Google.php
+++ b/lib/Storage/Google.php
@@ -60,18 +60,16 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 			&& isset($params['client_id']) && isset($params['client_secret'])
 			&& isset($params['token'])
 		) {
-			$this->client = new \Google_Client();
+			$config = [
+				'retry' => [
+					'retries' => 5
+				]
+			];
+			$this->client = new \Google_Client($config);
 			$this->client->setClientId($params['client_id']);
 			$this->client->setClientSecret($params['client_secret']);
 			$this->client->setScopes(['https://www.googleapis.com/auth/drive']);
 			$this->client->setAccessToken($params['token']);
-			// if curl isn't available we're likely to run into
-			// https://github.com/google/google-api-php-client/issues/59
-			// - disable gzip to avoid it.
-			if (!function_exists('curl_version') || !function_exists('curl_exec')) {
-				$this->client->setClassConfig("Google_Http_Request", "disable_gzip", true);
-			}
-			$this->client->setClassConfig('Google_Task_Runner', 'retries', 5);
 			// note: API connection is lazy
 			$this->service = new \Google_Service_Drive($this->client);
 			$token = json_decode($params['token'], true);


### PR DESCRIPTION
Fixes https://github.com/owncloud/files_external_gdrive/issues/5.

The handshake goes through but then the storage cannot be instantiated because we need to update the storage class to use the new APIs. To be done as part of https://github.com/owncloud/files_external_gdrive/issues/2