### PR TITLE
added support for changing root folder in google drive

### DIFF
--- a/lib/Backend/Google.php
+++ b/lib/Backend/Google.php
@@ -39,6 +39,7 @@ class Google extends Backend {
 			->setStorageClass('\OCA\Files_external_gdrive\Storage\Google')
 			->setText($l->t('Google Drive'))
 			->addParameters([
+                                    (new DefinitionParameter('root', $l->t('Root')))->setFlag(DefinitionParameter::FLAG_OPTIONAL),                               
 				// all parameters handled in OAuth2 mechanism
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)

--- a/lib/Storage/Google.php
+++ b/lib/Storage/Google.php
@@ -1,5 +1,5 @@
 <?php
-/* Adam Williamson <awilliam@redhat.com>
+/* @author Adam Williamson <awilliam@redhat.com>
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Bart Visscher <bartv@thisnet.nl>
  * @author Christopher Schäpers <kondou@ts.unde.re>
@@ -46,7 +46,6 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	private $root;
 
 	private static $tempFiles = [];
-	private static $prevRoot = null;
 
 	// Google Doc mimetypes
 	const FOLDER = 'application/vnd.google-apps.folder';
@@ -76,16 +75,13 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 			$token = json_decode($params['token'], true);
 			$this->id = 'google::'.substr($params['client_id'], 0, 30).$token['created'];
 			$this->root = isset($params['root']) ? $params['root'] : '';
-			if(!$this->is_dir('')) {
-				throw new \Exception("$this->root is not a valid root directory. Please check storage settings");
-			}
 		} else {
 			throw new \Exception('Creating Google storage failed');
 		}
 	}
 
 	public function getId() {
-		return $this->id;
+		return $this->id.'/'.$this->root;
 	}
 
 	/**
@@ -689,11 +685,6 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	}
 
 	public function hasUpdated($path, $time) {
-		// Changing virtual root must trigger an update
-		if ($this->root !== self::$prevRoot) {
-			self::$prevRoot = $this->root;
-			return true;
-		}
 		$appConfig = \OC::$server->getAppConfig();
 		if ($this->is_file($path)) {
 			return parent::hasUpdated($path, $time);


### PR DESCRIPTION
This adds another input in storage settings for google drive that allows users to choose a specific folder to use as a root folder for the drive in owncloud. 

![utan](https://user-images.githubusercontent.com/11146541/31319110-dfebd0ca-ac5d-11e7-90a6-803f4171ffa3.jpg)
Before

![med](https://user-images.githubusercontent.com/11146541/31319108-d981a9f8-ac5d-11e7-94c1-12c7ef78ac06.jpg)
After


