### PR TITLE
Fix certificate paths

### DIFF
--- a/lib/Storage/Google.php
+++ b/lib/Storage/Google.php
@@ -457,7 +457,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 							$response = $client->get($downloadUrl, [
 								'headers' => $httpRequest->getRequestHeaders(),
 								'stream' => true,
-								'verify' => realpath(__DIR__ . '/../../../3rdparty/google-api-php-client/src/Google/IO/cacerts.pem'),
+								'verify' => realpath(__DIR__ . '/../../vendor/google/apiclient/src/Google/IO/cacerts.pem'),
 							]);
 						} catch (RequestException $e) {
 							if(!is_null($e->getResponse())) {


### PR DESCRIPTION
Verified with debugger by inspecting `$options` within the called method and I could see the full path there.

Before this fix the value of "$options['verify']" was zero.
