### PR TITLE
Don't prevent default for jquery oauth event

### DIFF
--- a/js/gdrive.js
+++ b/js/gdrive.js
@@ -36,7 +36,7 @@ $(document).ready(function() {
 	 */
 	$('#files_external').on('oauth_step1', '.configuration', function (event, data) {
 		if (data['backend_id'] !== backendId) {
-			return false;	// means the trigger is not for this storage adapter
+			return;	// means the trigger is not for this storage adapter
 		}
 
 		// Redirects the User on success else displays an alert (with error message sent by backend)
@@ -45,7 +45,7 @@ $(document).ready(function() {
 
 	$('#files_external').on('oauth_step2', '.configuration', function (event, data) {
 		if (data['backend_id'] !== backendId || data['code'] === undefined) {
-			return false;		// means the trigger is not for this OAuth2 grant
+			return;		// means the trigger is not for this OAuth2 grant
 		}
 
 		OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)


### PR DESCRIPTION
This is necessary to allow handlers of other backends to run.

Ref https://github.com/owncloud/files_external_dropbox/issues/23

@Hemant-Mann please review