### PR TITLE
fix multi gdrive external storage bug

### DIFF
--- a/js/gdrive.js
+++ b/js/gdrive.js
@@ -22,38 +22,37 @@ $(document).ready(function() {
 			});
 			el.tooltip({placement: 'top'});
 			backendEl.append(el);
+
+			/**
+			 * ------- OAUTH2 Events ----------
+			 *
+			 * The files_external_{backendId} app's CUSTOM JS should handle the OAuth2 events itself
+			 * instead on relying on the core for the implemention. These two functions
+			 * [1] OCA.External.Settings.OAuth2.getAuthUrl, [2] OCA.External.Settings.OAuth2.verifyCode
+			 * abstract away the details of sending the request to backend for getting the AuthURL or
+			 * verifying the code, mounting the storage config etc
+			 */
+			$tr.on('oauth_step1', '.configuration', function (event, data) {
+				if (data['backend_id'] !== backendId) {
+					return;	// means the trigger is not for this storage adapter
+				}
+
+				// Redirects the User on success else displays an alert (with error message sent by backend)
+				OCA.External.Settings.OAuth2.getAuthUrl(backendUrl, data);
+			});
+
+			$tr.on('oauth_step2', '.configuration', function (event, data) {
+				if (data['backend_id'] !== backendId || data['code'] === undefined) {
+					return;		// means the trigger is not for this OAuth2 grant
+				}
+
+				OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)
+					.fail(function (message) {
+						OC.dialogs.alert(message,
+							t('files_external_gdrive', 'Error verifying OAuth2 Code for ' + backendId)
+						);
+					});
+			});
 		}
 	});
-
-	/**
-	 * ------- OAUTH2 Events ----------
-	 * 
-	 * The files_external_{backendId} app's CUSTOM JS should handle the OAuth2 events itself
-	 * instead on relying on the core for the implemention. These two functions
-	 * [1] OCA.External.Settings.OAuth2.getAuthUrl, [2] OCA.External.Settings.OAuth2.verifyCode
-	 * abstract away the details of sending the request to backend for getting the AuthURL or
-	 * verifying the code, mounting the storage config etc
-	 */
-	$('#files_external').on('oauth_step1', '.configuration', function (event, data) {
-		if (data['backend_id'] !== backendId) {
-			return;	// means the trigger is not for this storage adapter
-		}
-
-		// Redirects the User on success else displays an alert (with error message sent by backend)
-		OCA.External.Settings.OAuth2.getAuthUrl(backendUrl, data);
-	});
-
-	$('#files_external').on('oauth_step2', '.configuration', function (event, data) {
-		if (data['backend_id'] !== backendId || data['code'] === undefined) {
-			return;		// means the trigger is not for this OAuth2 grant
-		}
-
-		OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)
-		.fail(function (message) {
-			OC.dialogs.alert(message,
-				t('files_external_gdrive', 'Error verifying OAuth2 Code for ' + backendId)
-			);
-		});
-	});
-
 });


### PR DESCRIPTION
Port of https://github.com/owncloud/core/pull/34987
## Description
- Fixes bug on multiple gdrive account addition
- As @Lirein explained in https://github.com/owncloud/core/issues/31497#issue-325256774. currently `oauth2_step1` and `oauth_step2` handlers are always registering for the first container in `gdrive.js`. I moved them inside of `whenSelectBackend` event and registered each of them separately.

@op6sie, @Lirein please test if you available.

## Related Issue
closes #28,  closes #24 

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
 The changes tested manually with the following scenarios, all of that worked;
- Add single gdrive account. 
- Add multiple gdrive accounts. 
- Firstly, add an external owncloud storage and secondly add a gdrive account
- Firstly, add a gdrive account and secondly add an external owncloud storage.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

I used core/master when I test changes. Because of that, I bumped max-version to 11 temporarily in my local, but I did not add this `info.xml` change to the commit. @PVince81 should I add it?